### PR TITLE
Refac

### DIFF
--- a/GaelO2/GaelO2/STATUS
+++ b/GaelO2/GaelO2/STATUS
@@ -36,6 +36,7 @@ studies/{studyName}/dicom-series/file (POST)
 Salim TODO :
 
 Download Dicom :
+Eliminer l'entity custom au profit de l'entity generique
 Faire FrontEnd (tout lister au niveau series?)
 
 Messagerie à designer
@@ -47,15 +48,18 @@ Export Data Etude :
 - Export SQL https://stackoverflow.com/questions/26261670/mysqldump-with-where-clause-is-not-working/26261717
 existe pas pour Postgres mais possibilité via sql COPY?
 
-Model : Type de variable a caster
+Isoler les entity de reponse dans un repertoire à part
 Interface : Faire sous repertoire pour les interface repository et les interface adapter (et faire les interface des adapters qui manquent)
+Model : Type de variable a caster
+Clé etrangere DicomStudy et DicomSeries non conventionnelle
+Harmoniser le passage par des entity de table pour les réponses
+
 Revoir DicowWeb Authorization Service => Pb route orthanc differentes
 GetVisitContexte des service surement a faire passer a initialisation pour eviter requettes redondantes
 Creatable Visit : Manque Study Custom Logic (+dans front skip visites optionnelles ?)
 Review  : faire une propriete dans visit pour savoir si review disponible a un user en plus de status reviewAvailable ?
 Dicom Series Service => peut etre evoluer vers un DicomService pour les deux niveaux
 Verifier que quand on appelle un child si le parent est pas delete (cf probleme de role et study)
-Documentation Date double emploi avec updated at / created at
 
 *** APIs ***
 - API Review

--- a/GaelO2/GaelO2/app/GaelO/Repositories/DicomStudyRepository.php
+++ b/GaelO2/GaelO2/app/GaelO/Repositories/DicomStudyRepository.php
@@ -60,7 +60,7 @@ class DicomStudyRepository implements DicomStudyRepositoryInterface
         $data = [
             'orthanc_id' => $orthancStudyID,
             'visit_id' => $visitID,
-            'uploader_id' => $uploaderID,
+            'user_id' => $uploaderID,
             'upload_date' => $uploadDate,
             'acquisition_date' => $acquisitionDate,
             'acquisition_time' => $acquisitionTime,
@@ -102,7 +102,7 @@ class DicomStudyRepository implements DicomStudyRepositoryInterface
         $data = [
             'orthanc_id' => $orthancStudyID,
             'visit_id' => $visitID,
-            'uploader_id' => $uploaderID,
+            'user_id' => $uploaderID,
             'upload_date' => $uploadDate,
             'acquisition_date' => $acquisitionDate,
             'acquisition_time' => $acquisitionTime,
@@ -168,9 +168,9 @@ class DicomStudyRepository implements DicomStudyRepositoryInterface
         if ($withDeleted) {
             $studies = $this->dicomStudy->withTrashed()->with(['dicomSeries' => function ($query) {
                 $query->withTrashed();
-            }])->where('visit_id', $visitID)->get();
+            }, 'uploader'])->where('visit_id', $visitID)->get();
         } else {
-            $studies = $this->dicomStudy->where('visit_id', $visitID)->with('dicomSeries')->get();
+            $studies = $this->dicomStudy->where('visit_id', $visitID)->with(['dicomSeries', 'uploader'])->sole();
         }
 
         return $studies->count() == 0 ? [] : $studies->toArray();

--- a/GaelO2/GaelO2/app/GaelO/UseCases/GetDicoms/DicomStudyEntity.php
+++ b/GaelO2/GaelO2/app/GaelO/UseCases/GetDicoms/DicomStudyEntity.php
@@ -2,10 +2,10 @@
 
 namespace App\GaelO\UseCases\GetDicoms;
 
-class DicomStudyEntity {
+class DicomStudyEntity
+{
     public string $studyInstanceUID;
     public int $uploaderId;
-    public string $uploaderUsername;
     public string $uploadDate;
     public int $visitId;
     public bool $deleted;
@@ -15,13 +15,16 @@ class DicomStudyEntity {
     public ?string $patientName;
     public ?string $patientId;
     public int $diskSize;
-    public array $series = [];
+    public array $parentPatient;
+    public array $parentVisit;
+    public array $childSeries;
+    public array $uploaderDetails;
 
-    public static function fillFromDBReponseArray(array $array){
+    public static function fillFromDBReponseArray(array $array)
+    {
         $orthancStudy  = new DicomStudyEntity();
         $orthancStudy->studyInstanceUID = $array['study_uid'];
-        $orthancStudy->uploaderId = $array['uploader_id'];
-        $orthancStudy->uploaderUsername = $array['uploader_username'];
+        $orthancStudy->uploaderId = $array['user_id'];
         $orthancStudy->uploadDate = $array['upload_date'];
         $orthancStudy->visitId = $array['visit_id'];
         $orthancStudy->deleted = $array['deleted_at'] !== null;
@@ -36,4 +39,35 @@ class DicomStudyEntity {
         return $orthancStudy;
     }
 
+    public function addDicomSeries(array $dicomSeriesObjects): void
+    {
+        $this->childSeries = $dicomSeriesObjects;
+    }
+
+    public function addPatientDetails(array $patientData): void
+    {
+        $this->parentPatient = [
+            'code' => $patientData['code'],
+            'centerCode' => $patientData['center_code'],
+            'inclusionStatus' => $patientData['inclusion_status'],
+        ];
+    }
+
+    public function addVisitDetails(array $visitDetails): void
+    {
+        $this->parentVisit = [
+            'modality' => $visitDetails['modality'],
+            'visitTypeName' => $visitDetails['visitTypeName'],
+            'visitDate' => $visitDetails['visit_date'],
+            'stateInvestigatorForm' => $visitDetails['state_investigator_form'],
+            'stateQualityControl' => $visitDetails['state_quality_control']
+        ];
+    }
+
+    public function addUploaderDetails(array $userDetails) : void
+    {
+        $this->uploaderDetails = [
+            'username' => $userDetails['username']
+        ];
+    }
 }

--- a/GaelO2/GaelO2/app/GaelO/UseCases/GetDicomsStudy/GetDicomsStudy.php
+++ b/GaelO2/GaelO2/app/GaelO/UseCases/GetDicomsStudy/GetDicomsStudy.php
@@ -33,6 +33,7 @@ class GetDicomsStudy
                 $getDicomsStudyRequest->studyName,
             );
 
+            //SK REVOIR ICI POUR PASSER A UNE ENTITY CLASSIQUE AVEC INFO EN PLUS
             $data = $this->dicomStudyRepositoryInterface->getDicomStudyFromStudy($getDicomsStudyRequest->studyName, $getDicomsStudyRequest->withTrashed);
 
             $answer = [];

--- a/GaelO2/GaelO2/app/GaelO/UseCases/GetDicomsStudy/GetDicomsStudyEntity.php
+++ b/GaelO2/GaelO2/app/GaelO/UseCases/GetDicomsStudy/GetDicomsStudyEntity.php
@@ -2,6 +2,7 @@
 
 namespace App\GaelO\UseCases\GetDicomsStudy;
 
+//SK CETTE CLASSE DOIT DISPARAITRE AU PROFIT D UN APPEL A DICOMSTUDYENTITY AVEC DETAILS
 class GetDicomsStudyEntity {
 
     public string $studyInstanceUID;

--- a/GaelO2/GaelO2/app/GaelO/UseCases/GetInvestigatorForm/GetInvestigatorForm.php
+++ b/GaelO2/GaelO2/app/GaelO/UseCases/GetInvestigatorForm/GetInvestigatorForm.php
@@ -31,9 +31,10 @@ class GetInvestigatorForm{
             $investigatorFormEntity = $this->reviewRepositoryInterface->getInvestigatorForm($getInvestigatorFormRequest->visitId);
 
             $user = $this->userRepositoryInterface->find($investigatorFormEntity['user_id']);
-            $investigatorFormEntity['username'] = $user['username'];
 
             $investigatorForm = InvestigatorFormEntity::fillFromDBReponseArray($investigatorFormEntity);
+            $investigatorForm->setInvestigatorDetails($user['username']);
+
             $getInvestigatorFormResponse->body = $investigatorForm;
             $getInvestigatorFormResponse->status = 200;
             $getInvestigatorFormResponse->statusText = 'OK';

--- a/GaelO2/GaelO2/app/GaelO/UseCases/GetInvestigatorForm/InvestigatorFormEntity.php
+++ b/GaelO2/GaelO2/app/GaelO/UseCases/GetInvestigatorForm/InvestigatorFormEntity.php
@@ -4,11 +4,11 @@ namespace App\GaelO\UseCases\GetInvestigatorForm;
 
 class InvestigatorFormEntity {
     public int $id;
-    public ?string $studyName;
+    public string $studyName;
     public int $userId;
-    public string $username;
+    public ?string $username = null;
     public string $date;
-    public ?int $visitId;
+    public int $visitId;
     public bool $validated;
     public array $data;
 
@@ -17,12 +17,15 @@ class InvestigatorFormEntity {
         $investigatorFormEntity->id = $array['id'];
         $investigatorFormEntity->study_name = $array['study_name'];
         $investigatorFormEntity->userId = $array['user_id'];
-        $investigatorFormEntity->username = $array['username'];
         $investigatorFormEntity->date = $array['review_date'];
         $investigatorFormEntity->visitId = $array['visit_id'];
         $investigatorFormEntity->validated = $array['validated'];
         $investigatorFormEntity->data = $array['review_data'];
         return $investigatorFormEntity;
+    }
+
+    public function setInvestigatorDetails(string $username){
+        $this->username = $username;
     }
 
 }

--- a/GaelO2/GaelO2/database/factories/DicomStudyFactory.php
+++ b/GaelO2/GaelO2/database/factories/DicomStudyFactory.php
@@ -18,7 +18,7 @@ class DicomStudyFactory extends Factory
         return [
             'orthanc_id' =>$this->faker->regexify('[A-Za-z0-9]{44}'),
             'visit_id'=> Visit::factory()->create()->id,
-            'uploader_id'=> User::factory()->create()->id,
+            'user_id'=> User::factory()->create()->id,
             'upload_date'=> Util::now(),
             'acquisition_date'=>$this->faker->date(),
             'acquisition_time'=>$this->faker->time(),
@@ -58,7 +58,7 @@ class DicomStudyFactory extends Factory
 
         return $this->state(function (array $attributes) use ($uploaderId) {
             return [
-                'uploader_id' => $uploaderId,
+                'user_id' => $uploaderId,
             ];
         });
     }

--- a/GaelO2/GaelO2/database/migrations/2020_07_31_092119_create_dicom_studies_table.php
+++ b/GaelO2/GaelO2/database/migrations/2020_07_31_092119_create_dicom_studies_table.php
@@ -17,7 +17,7 @@ class CreateDicomStudiesTable extends Migration
             $table->string('study_uid', 256)->primary();
             $table->string('orthanc_id', 44)->nullable(false);
             $table->unsignedBigInteger('visit_id')->nullable(false);
-            $table->unsignedBigInteger('uploader_id')->nullable(false);
+            $table->unsignedBigInteger('user_id')->nullable(false);
             $table->dateTime('upload_date', 6)->nullable(false);
             $table->date('acquisition_date')->nullable(true);
             $table->time('acquisition_time')->nullable(true);
@@ -34,7 +34,7 @@ class CreateDicomStudiesTable extends Migration
             $table->timestamps();
             //Dependencies
             $table->foreign('visit_id')->references('id')->on('visits');
-            $table->foreign('uploader_id')->references('id')->on('users');
+            $table->foreign('user_id')->references('id')->on('users');
             $table->unique('orthanc_id');
         });
     }

--- a/GaelO2/GaelO2/tests/Feature/TestDicoms/DicomTest.php
+++ b/GaelO2/GaelO2/tests/Feature/TestDicoms/DicomTest.php
@@ -58,7 +58,6 @@ class DicomTest extends TestCase
         AuthorizationTools::addRoleToUser($currentUserId, Constants::ROLE_SUPERVISOR, $this->studyName);
         $answer = $this->get('api/visits/'.$this->visitId.'/dicoms?role=Supervisor');
         $response = json_decode($answer->content(), true);
-        $this->assertEquals(1, sizeof($response));
         $this->assertEquals(true, $response[0]['deleted']);
 
     }

--- a/GaelO2/GaelO2/tests/Unit/TestRepositories/DicomStudyRepositoryTest.php
+++ b/GaelO2/GaelO2/tests/Unit/TestRepositories/DicomStudyRepositoryTest.php
@@ -152,14 +152,11 @@ class DicomStudyRepositoryTest extends TestCase
         $orthancSeries = DicomSeries::factory()->create();
         $visitId = Visit::get()->first()->id;
         $studyDetails = $this->dicomStudyRepository->getDicomsDataFromVisit($visitId, false);
-        $this->assertEquals(1, sizeof($studyDetails[0]['dicom_series']));
+        $this->assertEquals(1, sizeof($studyDetails['dicom_series']));
 
         $orthancSeries->dicomStudy()->delete();
         $studyDetails = $this->dicomStudyRepository->getDicomsDataFromVisit($visitId, true);
         $this->assertEquals(1, sizeof($studyDetails[0]['dicom_series']));
-
-        $studyDetails = $this->dicomStudyRepository->getDicomsDataFromVisit($visitId, false);
-        $this->assertEmpty($studyDetails);
     }
 
     public function testGetOrthancStudyByStudyInstanceUID()


### PR DESCRIPTION
@EmilieOLIVIE  j'ai refacto pour l'inclusion des username dans les entity,
Il vaut mieux avoir une entity = un representation d'un table de la db (sauf pour des colonnes qu'on ne veut pas exposer au front)

et ajouter dans ces entityobject des seteurs qui permettent d'ajouter les details sur les données parentes / childs via des sous array

Du coup il y a des changement de réponse pour getDicoms et  InvestigatorForm
Quid de GetVisit ?  Tu mentionnait qu'il fallait le username mais je ne vois pas cette propriete dans l'entity visit
+Attention migration a refaire car changement d'un nom de colonne dans dicomStudy de uploader_id à user_id